### PR TITLE
Documented new props for onOpened and onClosed

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ class Example extends Component {
 - `expandedHeight` view height when expanded (defaults to window height)
 - `closeOnTap` if true, closes on tap
 - `closing` function called when hiding
+- `onClosed` function called after closing animations completed 
+- `onOpened` function called after opening animations completed 
 
 ## Contribute
 


### PR DESCRIPTION
For issue #2 
They get called in the Animated.start() callback if supplied.

See: https://github.com/facebook/react-native/issues/3212